### PR TITLE
Replace hardcoded passwords for Scorpio DB and other fixes

### DIFF
--- a/AllInOneRunner/pom.xml
+++ b/AllInOneRunner/pom.xml
@@ -40,42 +40,42 @@
 		<dependency>
 			<groupId>eu.neclab.ngsildbroker</groupId>
 			<artifactId>InfoServer</artifactId>
-			<version>2.0.0-SNAPSHOT</version>
+			<version>3.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>eu.neclab.ngsildbroker</groupId>
 			<artifactId>AtContextServer</artifactId>
-			<version>2.0.0-SNAPSHOT</version>
+			<version>3.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>eu.neclab.ngsildbroker</groupId>
 			<artifactId>EntityManager</artifactId>
-			<version>2.0.0-SNAPSHOT</version>
+			<version>3.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>eu.neclab.ngsildbroker</groupId>
 			<artifactId>HistoryManager</artifactId>
-			<version>2.0.0-SNAPSHOT</version>
+			<version>3.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>eu.neclab.ngsildbroker</groupId>
 			<artifactId>QueryManager</artifactId>
-			<version>2.0.0-SNAPSHOT</version>
+			<version>3.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>eu.neclab.ngsildbroker</groupId>
 			<artifactId>RegistryManager</artifactId>
-			<version>2.0.0-SNAPSHOT</version>
+			<version>3.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>eu.neclab.ngsildbroker</groupId>
 			<artifactId>StorageManager</artifactId>
-			<version>2.0.0-SNAPSHOT</version>
+			<version>3.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>eu.neclab.ngsildbroker</groupId>
 			<artifactId>SubscriptionManager</artifactId>
-			<version>2.0.0-SNAPSHOT</version>
+			<version>3.0.0-SNAPSHOT</version>
 		</dependency>
 		<!-- <dependency> <groupId>eu.neclab.ngsildbroker</groupId> <artifactId>eureka-server</artifactId> 
 			<version>1.0.0-SNAPSHOT</version> </dependency> <dependency> <groupId>eu.neclab.ngsildbroker</groupId> 

--- a/Core/AtContextServer/dockerfile4maven
+++ b/Core/AtContextServer/dockerfile4maven
@@ -1,6 +1,10 @@
 FROM openjdk:11-jre
 
+RUN useradd scorpio
 WORKDIR /usr/src/scorpio
+RUN chmod o+rw .
+USER scorpio
+
 ARG JAR_FILE_BUILD
 ARG JAR_FILE_RUN
 ENV JAR_FILE_RUN ${JAR_FILE_RUN}

--- a/Core/AtContextServer/pom.xml
+++ b/Core/AtContextServer/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>AtContextServer</artifactId>
 	<packaging>jar</packaging>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<parent>
 		<groupId>eu.neclab.ngsildbroker</groupId>
 		<artifactId>BrokerParent</artifactId>

--- a/Core/EntityManager/pom.xml
+++ b/Core/EntityManager/pom.xml
@@ -10,7 +10,7 @@
 		<version>1.0.0-SNAPSHOT</version>
 		<relativePath>../../BrokerParent</relativePath>
 	</parent>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<profiles>
 		<profile>
 			<id>docker</id>

--- a/Core/EntityManager/src/main/resources/application-dist.yml
+++ b/Core/EntityManager/src/main/resources/application-dist.yml
@@ -18,7 +18,7 @@ spring:
       maximumPoolSize: 20
       minimumIdle: 5
       poolName: SpringBootHikariCP
-    password: ngb
+    password: ${POSTGRES_PASSWORD}
     url: jdbc:postgresql://${POSTGRES_SERVICE}:${POSTGRES_PORT}/ngb?ApplicationName=ngb_registrymanager
     username: ngb
   flyway:
@@ -33,7 +33,7 @@ writer:
       maximumPoolSize: 20
       minimumIdle: 5
       poolName: SpringBootHikariCP_Writer
-    password: ngb
+    password: ${POSTGRES_PASSWORD}
     url: jdbc:postgresql://${POSTGRES_SERVICE}:${POSTGRES_PORT}/ngb?ApplicationName=ngb_entitymanager_writer
     username: ngb
   enabled: true
@@ -42,7 +42,7 @@ reader:
   datasource:
     url: "jdbc:postgresql://${POSTGRES_SERVICE}:${POSTGRES_PORT}/ngb?ApplicationName=ngb_entitymanager_reader"
     username: ngb
-    password: ngb
+    password: ${POSTGRES_PASSWORD}
     hikari:
       minimumIdle: 5
       maximumPoolSize: 20

--- a/Core/InfoServer/pom.xml
+++ b/Core/InfoServer/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>InfoServer</artifactId>
 	<packaging>jar</packaging>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<parent>
 		<groupId>eu.neclab.ngsildbroker</groupId>
 		<artifactId>BrokerParent</artifactId>

--- a/Core/QueryManager/pom.xml
+++ b/Core/QueryManager/pom.xml
@@ -9,7 +9,7 @@
 		<version>1.0.0-SNAPSHOT</version>
 		<relativePath>../../BrokerParent</relativePath>
 	</parent>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<profiles>
 		<profile>
 			<id>docker</id>

--- a/Core/QueryManager/src/main/resources/application-dist.yml
+++ b/Core/QueryManager/src/main/resources/application-dist.yml
@@ -25,7 +25,7 @@ spring:
   datasource:
     url: jdbc:postgresql://${POSTGRES_SERVICE}:${POSTGRES_PORT}/ngb?ApplicationName=ngb_querymanager
     username: ngb
-    password: ngb
+    password: ${POSTGRES_PASSWORD}
     hikari: 
       minimumIdle: 5
       maximumPoolSize: 20

--- a/Core/SubscriptionManager/dockerfile4maven
+++ b/Core/SubscriptionManager/dockerfile4maven
@@ -1,10 +1,11 @@
 FROM openjdk:11-jre
 
 #Run as non-root user
-#RUN useradd scorpio
-#USER scorpio
-
+RUN useradd scorpio
 WORKDIR /usr/src/scorpio
+RUN chmod o+rw .
+USER scorpio
+
 ARG JAR_FILE_BUILD
 ARG JAR_FILE_RUN
 ENV JAR_FILE_RUN ${JAR_FILE_RUN}

--- a/Core/SubscriptionManager/dockerfile4maven
+++ b/Core/SubscriptionManager/dockerfile4maven
@@ -1,8 +1,8 @@
 FROM openjdk:11-jre
 
 #Run as non-root user
-RUN useradd scorpio
-USER scorpio
+#RUN useradd scorpio
+#USER scorpio
 
 WORKDIR /usr/src/scorpio
 ARG JAR_FILE_BUILD

--- a/Core/SubscriptionManager/pom.xml
+++ b/Core/SubscriptionManager/pom.xml
@@ -10,7 +10,7 @@
 		<version>1.0.0-SNAPSHOT</version>
 		<relativePath>../../BrokerParent</relativePath>
 	</parent>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<profiles>
 		<profile>
 			<id>docker</id>

--- a/Core/SubscriptionManager/src/main/resources/application-dist.yml
+++ b/Core/SubscriptionManager/src/main/resources/application-dist.yml
@@ -33,7 +33,7 @@ spring:
       maximumPoolSize: 20
       minimumIdle: 5
       poolName: SpringBootHikariCP
-    password: ngb
+    password: ${POSTGRES_PASSWORD}
     url: jdbc:postgresql://${POSTGRES_SERVICE}:${POSTGRES_PORT}/ngb?ApplicationName=ngb_registrymanager
     username: ngb
 writer:
@@ -45,7 +45,7 @@ writer:
       maximumPoolSize: 20
       minimumIdle: 5
       poolName: SpringBootHikariCP_Writer
-    password: ngb
+    password: ${POSTGRES_PASSWORD}
     url: jdbc:postgresql://${POSTGRES_SERVICE}:${POSTGRES_PORT}/ngb?ApplicationName=ngb_storagemanager_writer
     username: ngb
   enabled: true
@@ -54,7 +54,7 @@ reader:
   datasource:
     url: "jdbc:postgresql://${POSTGRES_SERVICE}:${POSTGRES_PORT}/ngb?ApplicationName=ngb_storagemanager_reader"
     username: ngb
-    password: ngb
+    password: ${POSTGRES_PASSWORD}
     hikari:
       minimumIdle: 5
       maximumPoolSize: 20

--- a/History/HistoryManager/pom.xml
+++ b/History/HistoryManager/pom.xml
@@ -7,7 +7,7 @@
 	<packaging>jar</packaging>
 
 	<name>HistoryManager</name>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 
 	<parent>
 		<groupId>eu.neclab.ngsildbroker</groupId>

--- a/History/HistoryManager/src/main/resources/application-dist.yml
+++ b/History/HistoryManager/src/main/resources/application-dist.yml
@@ -29,7 +29,7 @@ spring:
   datasource:
     url: jdbc:postgresql://${POSTGRES_SERVICE}:${POSTGRES_PORT}/ngb?ApplicationName=ngb_querymanager
     username: ngb
-    password: ngb
+    password: ${POSTGRES_PASSWORD}
     hikari: 
       minimumIdle: 5
       maximumPoolSize: 20
@@ -43,7 +43,7 @@ reader:
   datasource:
     url: "jdbc:postgresql://${POSTGRES_SERVICE}:${POSTGRES_PORT}/ngb?ApplicationName=ngb_storagemanager_reader"
     username: ngb
-    password: ngb
+    password: ${POSTGRES_PASSWORD}
     hikari:
       minimumIdle: 5
       maximumPoolSize: 20
@@ -57,7 +57,7 @@ writer:
   datasource:
     url: "jdbc:postgresql://${POSTGRES_SERVICE}:${POSTGRES_PORT}/ngb?ApplicationName=ngb_storagemanager_writer"
     username: ngb
-    password: ngb
+    password: ${POSTGRES_PASSWORD}
     hikari:
       minimumIdle: 5
       maximumPoolSize: 20

--- a/OverallParent/pom.xml
+++ b/OverallParent/pom.xml
@@ -34,6 +34,13 @@
 				<scope>import</scope>
 			</dependency>
 			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-bom</artifactId>
+				<version>2.17.0</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
+			<dependency>
 				<!-- Import dependency management from Spring Boot -->
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>

--- a/Registry/RegistryManager/pom.xml
+++ b/Registry/RegistryManager/pom.xml
@@ -9,7 +9,7 @@
 		<version>1.0.0-SNAPSHOT</version>
 		<relativePath>../../BrokerParent</relativePath>
 	</parent>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<profiles>
 		<profile>
 			<id>docker</id>

--- a/Registry/RegistryManager/src/main/resources/application-dist.yml
+++ b/Registry/RegistryManager/src/main/resources/application-dist.yml
@@ -36,7 +36,7 @@ spring:
   datasource:
     url: jdbc:postgresql://${POSTGRES_SERVICE}:${POSTGRES_PORT}/ngb?ApplicationName=ngb_registrymanager
     username: ngb
-    password: ngb
+    password: ${POSTGRES_PASSWORD}
     hikari: 
       minimumIdle: 5
       maximumPoolSize: 20
@@ -50,7 +50,7 @@ reader:
   datasource:
     url: "jdbc:postgresql://${POSTGRES_SERVICE}:${POSTGRES_PORT}/ngb?ApplicationName=ngb_storagemanager_reader"
     username: ngb
-    password: ngb
+    password: ${POSTGRES_PASSWORD}
     hikari:
       minimumIdle: 5
       maximumPoolSize: 20
@@ -64,7 +64,7 @@ writer:
   datasource:
     url: "jdbc:postgresql://${POSTGRES_SERVICE}:${POSTGRES_PORT}/ngb?ApplicationName=ngb_storagemanager_writer"
     username: ngb
-    password: ngb
+    password: ${POSTGRES_PASSWORD}
     hikari:
       minimumIdle: 5
       maximumPoolSize: 20

--- a/SpringCloudModules/config-server/pom.xml
+++ b/SpringCloudModules/config-server/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<artifactId>config-server</artifactId>
 	<name>config-server</name>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<url>http://maven.apache.org</url>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/SpringCloudModules/eureka/pom.xml
+++ b/SpringCloudModules/eureka/pom.xml
@@ -15,7 +15,7 @@
 		<version>1.0.0-SNAPSHOT</version>
 		<relativePath>../../SpringCloudParent</relativePath>
 	</parent>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<profiles>
 		<profile>
 			<id>java-above-8-support</id>

--- a/SpringCloudModules/gateway/pom.xml
+++ b/SpringCloudModules/gateway/pom.xml
@@ -15,7 +15,7 @@
 		<version>1.0.0-SNAPSHOT</version>
 		<relativePath>../../SpringCloudParent</relativePath>
 	</parent>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 
 
 	<dependencies>

--- a/SpringCloudModules/spring-cloud-gateway/pom.xml
+++ b/SpringCloudModules/spring-cloud-gateway/pom.xml
@@ -15,7 +15,7 @@
 		<version>1.0.0-SNAPSHOT</version>
 		<relativePath>../../SpringCloudParent</relativePath>
 	</parent>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 
 
 	<dependencies>

--- a/Storage/StorageManager/dockerfile4maven
+++ b/Storage/StorageManager/dockerfile4maven
@@ -1,6 +1,10 @@
 FROM openjdk:11-jre
 
+RUN useradd scorpio
 WORKDIR /usr/src/scorpio
+RUN chmod o+rw .
+USER scorpio
+
 ARG JAR_FILE_BUILD
 ARG JAR_FILE_RUN
 ENV JAR_FILE_RUN ${JAR_FILE_RUN}

--- a/Storage/StorageManager/pom.xml
+++ b/Storage/StorageManager/pom.xml
@@ -9,7 +9,7 @@
 		<version>1.0.0-SNAPSHOT</version>
 		<relativePath>../../BrokerParent</relativePath>
 	</parent>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<profiles>
 		<profile>
 			<id>docker</id>

--- a/Storage/StorageManager/src/main/resources/application-dist.yml
+++ b/Storage/StorageManager/src/main/resources/application-dist.yml
@@ -23,7 +23,7 @@ reader:
   datasource:
     url: jdbc:postgresql://${POSTGRES_SERVICE}:${POSTGRES_PORT}/ngb?ApplicationName=ngb_storagemanager_reader
     username: ngb
-    password: ngb
+    password: ${POSTGRES_PASSWORD}
     hikari: 
       minimumIdle: 5
       maximumPoolSize: 20
@@ -37,7 +37,7 @@ writer:
   datasource:
     url: jdbc:postgresql://${POSTGRES_SERVICE}:${POSTGRES_PORT}/ngb?ApplicationName=ngb_storagemanager_writer
     username: ngb
-    password: ngb
+    password: ${POSTGRES_PASSWORD}
     hikari: 
       minimumIdle: 5
       maximumPoolSize: 20

--- a/docker-compose-dist.yml
+++ b/docker-compose-dist.yml
@@ -25,7 +25,7 @@ services:
       POSTGRES_PASSWORD: ngb
       POSTGRES_DB: ngb
   atctxsrv:
-    image: ibn40/digitaltwin:AtContextServer_2.0.0-SNAPSHOT
+    image: ibn40/digitaltwin:AtContextServer_3.0.0-SNAPSHOT
     ports:
       - "27015"
     env_file:
@@ -34,13 +34,13 @@ services:
       - kafka
       - eureka
   cfgsrv:
-    image: ibn40/digitaltwin:config-server_2.0.0-SNAPSHOT
+    image: ibn40/digitaltwin:config-server_3.0.0-SNAPSHOT
     ports:
       - "8888"
     depends_on:
       - eureka
   emgr:
-    image: ibn40/digitaltwin:EntityManager_2.0.0-SNAPSHOT
+    image: ibn40/digitaltwin:EntityManager_3.0.0-SNAPSHOT
     ports:
       - "1025"
     env_file:
@@ -48,17 +48,18 @@ services:
     environment:
       - CLIENT_ID=entity-manager
       - CLIENT_SECRET=
+      - POSTGRES_PASSWORD=ngb
     depends_on:
       - kafka
       - eureka
   eureka:
-    image: ibn40/digitaltwin:eureka-server_2.0.0-SNAPSHOT
+    image: ibn40/digitaltwin:eureka-server_3.0.0-SNAPSHOT
     ports:
       - "8761"
     env_file:
       - platform_services.env
   gateway:
-    image: ibn40/digitaltwin:gateway_2.0.0-SNAPSHOT
+    image: ibn40/digitaltwin:gateway_3.0.0-SNAPSHOT
     ports:
       - "9090:9090"
     env_file:
@@ -66,7 +67,7 @@ services:
     depends_on:
       - eureka
   histmgr:
-    image: ibn40/digitaltwin:HistoryManager_2.0.0-SNAPSHOT
+    image: ibn40/digitaltwin:HistoryManager_3.0.0-SNAPSHOT
     ports:
       - "1040"
     env_file:
@@ -74,12 +75,13 @@ services:
     environment:
       - CLIENT_ID=history-manager
       - CLIENT_SECRET=
+      - POSTGRES_PASSWORD=ngb
     depends_on:
       - kafka
       - gateway
       - eureka
   qrymgr:
-    image: ibn40/digitaltwin:QueryManager_2.0.0-SNAPSHOT
+    image: ibn40/digitaltwin:QueryManager_3.0.0-SNAPSHOT
     ports:
       - "1026"
     env_file:
@@ -87,12 +89,13 @@ services:
     environment:
       - CLIENT_ID=query-manager
       - CLIENT_SECRET=
+      - POSTGRES_PASSWORD=ngb
     depends_on:
       - kafka
       - postgres
       - eureka
   regmgr:
-    image: ibn40/digitaltwin:RegistryManager_2.0.0-SNAPSHOT
+    image: ibn40/digitaltwin:RegistryManager_3.0.0-SNAPSHOT
     ports:
       - "1030"
     env_file:
@@ -100,23 +103,26 @@ services:
     environment:
       - CLIENT_ID=registry-manager
       - CLIENT_SECRET=
+      - POSTGRES_PASSWORD=ngb
     depends_on:
       - kafka
       - postgres
       - gateway
       - eureka
   stomgr:
-    image: ibn40/digitaltwin:StorageManager_2.0.0-SNAPSHOT
+    image: ibn40/digitaltwin:StorageManager_3.0.0-SNAPSHOT
     ports:
       - "1029"
     env_file:
       - platform_services.env
+    environment:
+      - POSTGRES_PASSWORD=ngb
     depends_on:
       - kafka
       - postgres
       - eureka
   sbsmgr:
-    image: ibn40/digitaltwin:SubscriptionManager_2.0.0-SNAPSHOT
+    image: ibn40/digitaltwin:SubscriptionManager_3.0.0-SNAPSHOT
     ports:
       - "2025"
     env_file:
@@ -124,6 +130,7 @@ services:
     environment:
       - CLIENT_ID=subscription-manager
       - CLIENT_SECRET=
+      - POSTGRES_PASSWORD=ngb
     depends_on:
       - kafka
       - eureka

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 		<version>1.0.0-SNAPSHOT</version>
 		<relativePath>./OverallParent</relativePath>
 	</parent>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 
 
 	<modules>


### PR DESCRIPTION
Replace instances of hardcoded passwords for DB user `ngb` in all
`application-dist.yml` for ScorpioBroker services with environment
variable `POSTGRES_PASSWORD`. The DB user password is randomly
generated by the Zalando Postgres Operator and stored in a Kubernetes
secret. When deploying Scorpio using Helm, the environment variables
are initialised with this secret.

Resolves: IndustryFusion/DigitalTwin#67
Related: IndustryFusion/DigitalTwin#26